### PR TITLE
Always include source when calling airplane API

### DIFF
--- a/internal/api/client.ts
+++ b/internal/api/client.ts
@@ -20,6 +20,7 @@ export class Client {
     const apiKey = opts.apiKey || env?.AIRPLANE_API_KEY;
     const envID = opts.envID || env?.AIRPLANE_ENV_ID;
     const envSlug = opts.envSlug || env?.AIRPLANE_ENV_SLUG;
+    const source = opts.source || "sdk/node";
 
     this.fetcher = new Fetcher({
       host,
@@ -27,7 +28,7 @@ export class Client {
       apiKey,
       envID,
       envSlug,
-      source: opts?.source,
+      source,
     });
   }
 


### PR DESCRIPTION
Always include a source in the headers when making a request to the airplane api - if one isn't explicitly specified, we use `"sdk/node"`